### PR TITLE
Add event for handle being dragged

### DIFF
--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -155,6 +155,8 @@ define([
         var outOffset = thisSeg.view.frameOffset + thisSeg.outMarker.getX();
         segment.endTime = thisSeg.view.data.time(outOffset);
       }
+      
+      peaks.emit("segments.handle_dragged");
 
       updateSegmentWaveform(segment);
     };


### PR DESCRIPTION
I would find it useful for there to be an event that's fired when a segment handle is dragged. I couldn't see events being tested anywhere, so i haven't added a test. I hope I'm contributing this in a sensible way, and in the correct place! Let me know if not.