### PR TITLE
Make the axis label and gridline colors configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ var options = {
   // Colour of the play head
   playheadColor: 'rgba(0, 0, 0, 1)',
 
+  // Colour of the axis gridlines
+  axisGridlineColor: '#ccc',
+
+  // Colour of the axis labels
+  axisLabelColor: '#aaa',
+
   // Random colour per segment (overrides segmentColor)
   randomizeSegmentColor: true,
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "LGPL 3",
   "scripts": {
     "build": "browserify -d ./src/main.js -p [minifyify --map peaks.min.map --output peaks.min.map] -s peaks -o peaks.min.js",
+    "build-max": "browserify ./src/main.js -s peaks -o peaks.js",
     "test": "npm run test-pre && ./node_modules/karma/bin/karma start --single-run",
     "test-pre": "jshint ./src",
     "test-watch": "./node_modules/karma/bin/karma start --auto-watch --no-single-run",

--- a/src/main.js
+++ b/src/main.js
@@ -111,6 +111,14 @@ define('peaks', [
        */
       playheadColor:         'rgba(0, 0, 0, 1)',
       /**
+       * Colour of the axis gridlines
+      */
+      axisGridlineColor:     '#ccc',
+      /**
+       * Colour of the axis labels
+       */
+      axisLabelColor:        '#aaa',
+      /**
        *
        */
       template:              [

--- a/src/main/waveform/waveform.axis.js
+++ b/src/main/waveform/waveform.axis.js
@@ -96,12 +96,12 @@ define(["peaks/waveform/waveform.mixins", "Kinetic"], function (mixins, Kinetic)
     // Distance between waveform start time and first axis marker (pixels)
     var axisLabelOffsetPixels = this.view.data.at_time(axisLabelOffsetSecs);
 
-    context.setAttr('strokeStyle', '#ccc');
+    context.setAttr('strokeStyle', this.view.options.axisGridlineColor);
     context.setAttr('lineWidth', 1);
 
     // Set text style
     context.setAttr('font', "11px sans-serif");
-    context.setAttr('fillStyle', "#aaa");
+    context.setAttr('fillStyle', this.view.options.axisLabelColor);
     context.setAttr('textAlign', "left");
     context.setAttr('textBaseline', "bottom");
 

--- a/src/main/waveform/waveform.axis.js
+++ b/src/main/waveform/waveform.axis.js
@@ -96,14 +96,14 @@ define(["peaks/waveform/waveform.mixins", "Kinetic"], function (mixins, Kinetic)
     // Distance between waveform start time and first axis marker (pixels)
     var axisLabelOffsetPixels = this.view.data.at_time(axisLabelOffsetSecs);
 
-    context.strokeStyle = "#ccc";
-    context.lineWidth = 1;
+    context.setAttr('strokeStyle', '#ccc');
+    context.setAttr('lineWidth', 1);
 
     // Set text style
-    context.font = "11px sans-serif";
-    context.fillStyle = "#aaa";
-    context.textAlign = "left";
-    context.textBaseline = "bottom";
+    context.setAttr('font', "11px sans-serif");
+    context.setAttr('fillStyle', "#aaa");
+    context.setAttr('textAlign', "left");
+    context.setAttr('textBaseline', "bottom");
 
     var secs = firstAxisLabelSecs;
     var x;


### PR DESCRIPTION
This also fixes a regression from the KineticJS upgrade, which broke painting the axis in anything other than black. Using `setAttr` on the context makes it work as expected and now the axis is painted in the correct color.