### PR TITLE
Explicit segment draw on drag resize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+sudo: false
 cache:
   directories:
   - node_modules
+  - bower_components
 env:
   global:
   - secure: Bg08bmtZxlt18xVd7IT3Ft8rC8Cd3iT2txSqoFKaUERu2FzlaPvi+DS5K0SeOqAB9LfyRST/Msdg+jmPEvQ/0VXa2lfhqf31YSrXStnd9h1Owxr53KPV3O6FX1mfH8RlmHVDosKUR6mJeiush4MSEFPCmB1VBTwpyRcbBt3sbJ0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: '0.10'
+node_js:
+  - '0.10'
+  - '0.12'
 cache:
   directories:
   - node_modules
@@ -25,3 +27,7 @@ script:
 - npm start & sleep 2
 - npm run test-pre
 - ./node_modules/karma/bin/karma start --browsers Firefox --single-run
+
+matrix:
+  allow_failures:
+    - node_js: '0.12'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "type": "git",
     "url": "git://github.com/bbcrd/peaks.js.git"
   },
-  "license": "LGPL 3",
+  "license": "LGPL-3.0",
   "scripts": {
     "build": "browserify -d ./src/main.js -p [minifyify --map peaks.min.map --output peaks.min.map] -s peaks -o peaks.min.js",
     "test": "npm run test-pre && ./node_modules/karma/bin/karma start --single-run",

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -108,7 +108,6 @@ define([
       // segment.overview.label.setX(overviewStartOffset);
 
       SegmentShape.update.call(segment.overview.waveformShape, peaks.waveform.waveformOverview, segment.id);
-      segment.overview.view.segmentLayer.draw();
 
       // Zoom
       var zoomStartOffset = peaks.waveform.waveformZoomView.data.at_time(segment.startTime);
@@ -136,9 +135,6 @@ define([
         }
 
         SegmentShape.update.call(segment.zoom.waveformShape, peaks.waveform.waveformZoomView, segment.id);
-
-        segment.zoom.view.segmentLayer.draw();
-
       } else {
         segment.zoom.hide();
       }
@@ -156,7 +152,8 @@ define([
       }
 
       updateSegmentWaveform(segment);
-    };
+      this.render();
+    }.bind(this);
 
     var getSegmentColor = function () {
       var c;


### PR DESCRIPTION
Drawing within `updateSegmentWaveform` performs too many renders.

fix #119