### PR TITLE
Make more colors configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,17 @@ var options = {
   // Colour for the overview waveform
   overviewWaveformColor: 'rgba(0,0,0,0.2)',
 
+  // Colour for the overview waveform rectangle that shows what the zoom view shows
+  overviewHighlightRectangleColor: 'grey',
+
   // Colour for segments on the waveform
   segmentColor: 'rgba(255, 161, 39, 1)',
 
   // Colour of the play head
   playheadColor: 'rgba(0, 0, 0, 1)',
+
+  // Colour of the play head text
+  playheadTextColor: '#aaa',
 
   // Colour of the axis gridlines
   axisGridlineColor: '#ccc',

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ var options = {
   // Colour of the play head text
   playheadTextColor: '#aaa',
 
+  // the color of a point marker
+  pointMarkerColor: '#FF0000',
+
   // Colour of the axis gridlines
   axisGridlineColor: '#ccc',
 

--- a/src/main.js
+++ b/src/main.js
@@ -95,6 +95,11 @@ define('peaks', [
        */
       overviewWaveformColor: 'rgba(0,0,0,0.2)',
       /**
+       * Colour for the overview waveform highlight rectangle, which shows
+       * you what you see in the zoom view.
+       */
+      overviewHighlightRectangleColor: 'grey',
+      /**
        * Random colour per segment (overrides segmentColor)
        */
       randomizeSegmentColor: true,
@@ -110,6 +115,10 @@ define('peaks', [
        * Colour of the play head
        */
       playheadColor:         'rgba(0, 0, 0, 1)',
+      /**
+       * Colour of the play head text
+       */
+      playheadTextColor:     '#aaa',
       /**
        * Colour of the axis gridlines
       */

--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -129,10 +129,10 @@ define([
       x: 0,
       y: 11,
       width: 0,
-      stroke: "grey",
+      stroke: that.options.overviewHighlightRectangleColor,
       strokeWidth: 1,
       height: this.height - (11*2),
-      fill: 'grey',
+      fill: that.options.overviewHighlightRectangleColor,
       opacity: 0.3,
       cornerRadius: 2
     });

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -202,7 +202,7 @@ define([
       text: "00:00:00",
       fontSize: 11,
       fontFamily: 'sans-serif',
-      fill: '#aaa',
+      fill: that.options.playheadTextColor,
       align: 'right'
     });
 


### PR DESCRIPTION
This PR adds more configuration options for setting colors. Specifically:

* The overview highlight rectangle (if you have a better name, let me know). The grey blob in the overview.
* The text color of the playhead.