### PR TITLE
Fix typo, seeking instead of seaking

### DIFF
--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -75,7 +75,7 @@ define([
     // EVENTS ====================================================
 
     function trackPlayheadPosition(time, frame){
-      if (!peaks.seaking) {
+      if (!peaks.seeking) {
         that.playheadPixel = that.data.at_time(time);
         that.updateUi(that.playheadPixel);
       }


### PR DESCRIPTION
You have a typo in waveform.overview.js, this fixes it :)