### PR TITLE
Allow alternate zoom adapters, add a static (non-animated) zoom adapter, add more safety checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ var options = {
   // Random colour per segment (overrides segmentColor)
   randomizeSegmentColor: true,
 
-  // Zoom view adapter to use. Valid adapters are: 'AnimatedZoomAdapter' (default) and 'StaticZoomAdapter'
-  zoomAdapter: 'AnimatedZoomAdapter',
+  // Zoom view adapter to use. Valid adapters are: 'animated' (default) and 'static'
+  zoomAdapter: 'animated',
 
   // Array of initial segment objects with startTime and
   // endTime in seconds and a boolean for editable.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ var options = {
   // Random colour per segment (overrides segmentColor)
   randomizeSegmentColor: true,
 
+  // Use animations upon zoom
+  zoomAnimationEnabled: true,
+
   // Array of initial segment objects with startTime and
   // endTime in seconds and a boolean for editable.
   // See below.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ var options = {
   // Random colour per segment (overrides segmentColor)
   randomizeSegmentColor: true,
 
-  // Use animations upon zoom
-  zoomAnimationEnabled: true,
+  // Zoom view adapter to use. Valid adapters are: 'AnimatedZoomAdapter' (default) and 'StaticZoomAdapter'
+  zoomAdapter: 'AnimatedZoomAdapter',
 
   // Array of initial segment objects with startTime and
   // endTime in seconds and a boolean for editable.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "peaks/views/waveform.overview": "./src/main/views/waveform.overview.js",
     "peaks/views/waveform.zoomview": "./src/main/views/waveform.zoomview.js",
     "peaks/views/zooms/animated": "./src/main/views/zooms/animated.js",
+    "peaks/views/zooms/static": "./src/main/views/zooms/static.js",
     "peaks/markers/waveform.points": "./src/main/markers/waveform.points.js",
     "peaks/markers/waveform.segments": "./src/main/markers/waveform.segments.js",
     "peaks/markers/shapes/base": "./src/main/markers/shapes/base.js",

--- a/src/main.js
+++ b/src/main.js
@@ -147,10 +147,10 @@ define('peaks', [
         scale_adjuster: 127
        },
 
-       /**
-        * Use animation on zoom
-        */
-      zoomAnimationEnabled: true,
+      /**
+       * Use animation on zoom
+       */
+      zoomAdapter: 'AnimatedZoomAdapter',
     };
 
     /**

--- a/src/main.js
+++ b/src/main.js
@@ -145,7 +145,12 @@ define('peaks', [
        waveformBuilderOptions: {
         scale: 512,
         scale_adjuster: 127
-       }
+       },
+
+       /**
+        * Use animation on zoom
+        */
+      zoomAnimationEnabled: true,
     };
 
     /**

--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ define('peaks', [
       /**
        * Use animation on zoom
        */
-      zoomAdapter: 'AnimatedZoomAdapter',
+      zoomAdapter: 'animated',
     };
 
     /**

--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -183,6 +183,9 @@ define([
   };*/
 
   WaveformOverview.prototype.updateRefWaveform = function (time_in, time_out) {
+    if (isNaN(time_in))  throw new Error("WaveformOverview#updateRefWaveform passed a time in that is not a number: " + time_in);
+    if (isNaN(time_out)) throw new Error("WaveformOverview#updateRefWaveform passed a time out that is not a number: " + time_out);
+
     var that = this;
 
     var offset_in = that.data.at_time(time_in);
@@ -199,6 +202,8 @@ define([
   };
 
   WaveformOverview.prototype.updateUi = function (pixel) {
+    if (isNaN(pixel)) throw new Error("WaveformOverview#updateUi passed a value that is not a number: " + pixel);
+
     var that = this;
 
     that.playheadLine.setAttr("x", pixel);

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -218,6 +218,8 @@ define([
   };
 
   WaveformZoomView.prototype.updateZoomWaveform = function (pixelOffset) {
+    if (isNaN(pixelOffset)) throw new Error("WaveformZoomView#updateZoomWaveform passed a pixel offset that is not a number: " + pixelOffset);
+
     var that = this;
 
     that.frameOffset = pixelOffset;
@@ -275,6 +277,8 @@ define([
   };
 
   WaveformZoomView.prototype.newFrame = function (frameOffset) {
+    if (isNaN(frameOffset)) throw new Error("WaveformZoomView#newFrame passed a frame offset that is not a number: " + frameOffset);
+
     var nextOffset = frameOffset + this.width;
 
     if (nextOffset < this.data.adapter.length){
@@ -288,6 +292,8 @@ define([
   };
 
   WaveformZoomView.prototype.syncPlayhead = function (pixelIndex) {
+    if (isNaN(pixelIndex)) throw new Error("WaveformZoomView#syncPlayhead passed a pixel index that is not a number: " + pixelIndex);
+
     var that = this;
     var display = (pixelIndex >= that.frameOffset) && (pixelIndex <= that.frameOffset + that.width);
 
@@ -306,6 +312,8 @@ define([
   };
 
   WaveformZoomView.prototype.seekFrame = function (pixelIndex, offset) {
+    if (isNaN(pixelIndex)) throw new Error("WaveformZoomView#seekFrame passed a pixel index that is not a number: " + pixelIndex);
+
     var that = this;
     var upperLimit = that.data.adapter.length - that.width;
     var direction = pixelIndex < that.data.offset_start ? 'backwards' : 'onwards';

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -10,8 +10,9 @@ define([
   "peaks/waveform/waveform.axis",
   "peaks/waveform/waveform.mixins",
   "peaks/views/zooms/animated",
+  "peaks/views/zooms/static",
   "Kinetic"
-  ], function (WaveformAxis, mixins, ZoomAnimation, Kinetic) {
+  ], function (WaveformAxis, mixins, AnimatedZoomAdapter, StaticZoomAdapter, Kinetic) {
   'use strict';
 
   function WaveformZoomView(waveformData, container, peaks) {
@@ -135,6 +136,8 @@ define([
     });
 
     that.peaks.on("zoom.update", function (current_scale, previous_scale) {
+      var adapterClass, adapter;
+
       if (that.playing) {
         return;
       }
@@ -144,15 +147,20 @@ define([
           scale: current_scale
         });
 
-        if (that.peaks.options.zoomAnimationEnabled) {
-          var animation = ZoomAnimation.init(current_scale, previous_scale, that);
-          animation.start();
-        } else {
-          that.segmentLayer.draw();
-          that.pointLayer.draw();
-
-          that.seekFrame(that.data.at_time(that.peaks.time.getCurrentTime()));
+        switch(that.peaks.options.zoomAdapter) {
+          case 'AnimatedZoomAdapter':
+            adapterClass = AnimatedZoomAdapter;
+            break;
+          case 'StaticZoomAdapter':
+            adapterClass = StaticZoomAdapter;
+            break;
+          default:
+            throw new Error("Invalid zoomAdapter: " + that.peaks.options.zoomAdapter);
+            break;
         }
+
+        adapter = adapterClass.init(current_scale, previous_scale, that);
+        adapter.start();
       }
     });
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -226,12 +226,27 @@ define([
 
   WaveformZoomView.prototype.updateZoomWaveform = function (pixelOffset) {
     if (isNaN(pixelOffset)) throw new Error("WaveformZoomView#updateZoomWaveform passed a pixel offset that is not a number: " + pixelOffset);
-
     var that = this;
 
-    that.frameOffset = pixelOffset;
     that.pixelLength = that.data.adapter.length;
-    that.data.offset(pixelOffset, pixelOffset + that.width);
+
+    // total waveform is shorter than viewport, so reset the offset to 0
+    if (that.pixelLength < that.width) {
+      pixelOffset = 0;
+    }
+
+    // new position is beyond the size of the waveform, so set it to the very last possible position
+    if (pixelOffset > that.pixelLength) {
+      pixelOffset = that.pixelLength - that.width;
+    }
+
+    //
+    if (pixelOffset < 0) {
+      pixelOffset = 0;
+    }
+
+    that.frameOffset = pixelOffset;
+    that.data.offset(pixelOffset, Math.min(pixelOffset + that.width, that.pixelLength));
 
     var display = (that.playheadPixel >= pixelOffset) && (that.playheadPixel <= pixelOffset + that.width); //i.e. playhead is within the zoom frame width
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -144,8 +144,15 @@ define([
           scale: current_scale
         });
 
-        var animation = ZoomAnimation.init(current_scale, previous_scale, that);
-        animation.start();
+        if (that.peaks.options.zoomAnimationEnabled) {
+          var animation = ZoomAnimation.init(current_scale, previous_scale, that);
+          animation.start();
+        } else {
+          that.segmentLayer.draw();
+          that.pointLayer.draw();
+
+          that.seekFrame(that.data.at_time(that.peaks.time.getCurrentTime()));
+        }
       }
     });
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -240,7 +240,7 @@ define([
       pixelOffset = that.pixelLength - that.width;
     }
 
-    //
+    // we must not have a negative pixelOffset
     if (pixelOffset < 0) {
       pixelOffset = 0;
     }

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -136,7 +136,7 @@ define([
     });
 
     that.peaks.on("zoom.update", function (current_scale, previous_scale) {
-      var adapterClass, adapter;
+      var adapter, zoomAdapterMap;
 
       if (that.playing) {
         return;
@@ -147,19 +147,16 @@ define([
           scale: current_scale
         });
 
-        switch(that.peaks.options.zoomAdapter) {
-          case 'AnimatedZoomAdapter':
-            adapterClass = AnimatedZoomAdapter;
-            break;
-          case 'StaticZoomAdapter':
-            adapterClass = StaticZoomAdapter;
-            break;
-          default:
-            throw new Error("Invalid zoomAdapter: " + that.peaks.options.zoomAdapter);
-            break;
+        zoomAdapterMap = {
+          'animated': AnimatedZoomAdapter,
+          'static': StaticZoomAdapter
         }
 
-        adapter = adapterClass.init(current_scale, previous_scale, that);
+        if (zoomAdapterMap[that.peaks.options.zoomAdapter] === undefined) {
+          throw new Error("Invalid zoomAdapter: " + that.peaks.options.zoomAdapter);
+        }
+
+        adapter = zoomAdapterMap[that.peaks.options.zoomAdapter].init(current_scale, previous_scale, that);
         adapter.start();
       }
     });

--- a/src/main/views/zooms/static.js
+++ b/src/main/views/zooms/static.js
@@ -3,7 +3,7 @@
  *
  * This module is a zoom view adapter with no animations.
  */
-define(["Kinetic"], function (Kinetic) {
+define([], function () {
   'use strict';
 
   return {

--- a/src/main/views/zooms/static.js
+++ b/src/main/views/zooms/static.js
@@ -1,0 +1,21 @@
+/**
+ * ZOOMS.STATIC.JS
+ *
+ * This module is a zoom view adapter with no animations.
+ */
+define(["Kinetic"], function (Kinetic) {
+  'use strict';
+
+  return {
+    init: function (currentSampleRate, previousSampleRate, view) {
+      return {
+        start: function() {
+          view.segmentLayer.draw();
+          view.pointLayer.draw();
+
+          view.seekFrame(view.data.at_time(view.peaks.time.getCurrentTime()));
+        }
+      }
+    },
+  };
+});


### PR DESCRIPTION
We have some really large (3+ hours at 256 samples/pixel!) audio files where zoom is never really going to be performant, so we wanted to be able to turn zoom off.

This PR also adds safety checks (some of which are already in #118, see commit 1395290) to prevent doing things which are incorrect.