### PR TITLE
Bugfix: Don't add waveform layer to the overview stage twice and ensure the UI layer is on top

### DIFF
--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -44,8 +44,6 @@ define([
     that.createRefWaveform();
     that.createUi();
 
-    that.stage.add(that.waveformLayer);
-
     // INTERACTION ===============================================
     var cancelSeeking = function(){
       that.stage.off("mousemove mouseup");
@@ -156,6 +154,7 @@ define([
 
     this.uiLayer.add(this.playheadLine);
     this.stage.add(this.uiLayer);
+    this.uiLayer.moveToTop();
   };
 
   /*WaveformOverview.prototype.updateWaveform = function () {


### PR DESCRIPTION
`createWaveform` adds the waveform layer to the stage already, but then we re-add it to the stage. I'm unsure exactly what effect this has (@johvet probably does), but it definitely seems incorrect. The UI layer also needed to be moved on top of the other layers, because the waveform was covering up the playhead and other important bits.