### PR TITLE
Serve media from Karma during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,4 @@ before_script:
 - sh -e /etc/init.d/xvfb start
 - npm run build
 script:
-- npm start & sleep 2
 - npm test -- --browsers Firefox --single-run

--- a/test/audioElement.html
+++ b/test/audioElement.html
@@ -1,4 +1,4 @@
 <audio id="audioElement" controls preload>
-  <source src="http://localhost:9000/test_data/sample.mp3" type="audio/mpeg">
-  <source src="http://localhost:9000/test_data/sample.ogg" type="audio/ogg">
+  <source src="/base/test_data/sample.mp3" type="audio/mpeg">
+  <source src="/base/test_data/sample.ogg" type="audio/ogg">
 </audio>


### PR DESCRIPTION
I think the second server is responsible for random test failures on Travis, we can probably make it more reliable just by serving everything through Karma.

(Unless the separate server was intentional, as an integration test for CORS..?)