### PR TITLE
Improve `addSegment` signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ console.log(instance.zoom.getZoom()); // -> 1
 **Segments** give the ability to visually tag timed portions of a media object.
 This is a great way to provide visual cues to your users.
 
-### `instance.segments.add(startTime, endTime, editable, color, labelText)`
+### `instance.segments.add({startTime, endTime, editable, color, labelText})`
 ### `instance.segments.add(segment[])`
 
 Add a segment to the waveform timeline with starting time `startTime` (seconds), ending time `endTime` (seconds)
@@ -365,7 +365,7 @@ and set whether the segment is user editable with `editable` (boolean, defaults 
 ```js
 var instance = peaks.init({ … });
 
-instance.segments.add(0, 10.5); //adds a 0 to 10.5 seconds non-editable segment with a random color
+instance.segments.add({startTime: 0, endTime: 10.5}); //adds a 0 to 10.5 seconds non-editable segment with a random color
 ```
 
 Alternatively, provide an array of segment objects as shown above in the config options as the first and only argument to add all those segments at once.

--- a/src/main.js
+++ b/src/main.js
@@ -386,30 +386,27 @@ define('peaks', [
         return {
           /**
            *
-           * @param timeStamp
-           * @param editable
-           * @param color
-           * @param labelText
+           * @param {(...Object|Object[])} pointOrPoints
+           * @param {Number} pointOrPoints[].timestamp
+           * @param {Boolean=} pointOrPoints[].editable
+           * @param {String=} pointOrPoints[].color
+           * @param {String=} pointOrPoints[].labelText
            */
-          add: function (timestamp, editable, color, labelText) {
-            var points = arguments[0];
+          add: function (pointOrPoints) {
+            var points = Array.isArray(arguments[0]) ? arguments[0] : Array.prototype.slice.call(arguments);
 
-            if (typeof points === "number") {
+            if (typeof points[0] === "number") {
+              self.options.deprecationLogger("[Peaks.points.add] Passing spread-arguments to `add` is deprecated, please pass a single object");
               points = [{
-                timestamp: timestamp,
-                editable:  editable,
-                color:     color,
-                labelText: labelText
+                timestamp: arguments[0],
+                editable:  arguments[1],
+                color:     arguments[2],
+                labelText: arguments[3]
               }];
             }
 
-            if (Array.isArray(points)) {
-              points.forEach(self.waveform.points.createPoint.bind(self.waveform.points));
-              self.waveform.points.render();
-            }
-            else {
-              throw new TypeError("[Peaks.points.addPoint] Unrecognized point parameters.");
-            }
+            points.forEach(self.waveform.points.createPoint.bind(self.waveform.points));
+            self.waveform.points.render();
           },
           /**
            *

--- a/src/main.js
+++ b/src/main.js
@@ -302,13 +302,7 @@ define('peaks', [
             ];
           }
 
-          segments.forEach(function (segment) {
-            if (typeof segment.startTime !== 'number') {
-              throw new TypeError("[Peaks.segments.addSegment] Unrecognized segment parameters.");
-            }
-            self.waveform.segments.createSegment(segment.startTime, segment.endTime, segment.editable, segment.color, segment.labelText);
-          });
-
+          segments.forEach(self.waveform.segments.createSegment.bind(self.waveform.segments));
           self.waveform.segments.render();
         }
 

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -112,7 +112,9 @@ define([
     };
 
     this.createPoint = function (point) {
-
+      if (typeof point.timestamp !== 'number') {
+        throw new TypeError("[waveform.points.createPoint] timestamp should be a numeric value '" + typeof point.timestamp + "': " + point.typestamp);
+      }
       if ((point.timestamp >= 0) === false) {
         throw new RangeError("[waveform.points.createPoint] timestamp should be a >=0 value");
       }

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -25,14 +25,15 @@ define([
       return view;
     });
 
-    var createSegmentWaveform = function (segmentId, startTime, endTime, editable, color, labelText) {
+    var createSegmentWaveform = function (options) {
+      var segmentId = "segment" + self.segments.length;
       var segment = {
         id: segmentId,
-        startTime: startTime,
-        endTime: endTime,
-        labelText: labelText || "",
-        color: color || getSegmentColor(),
-        editable: editable
+        startTime: options.startTime,
+        endTime: options.endTime,
+        labelText: options.labelText || "",
+        color: options.color || getSegmentColor(),
+        editable: options.editable || false
       };
 
       var segmentZoomGroup = new Konva.Group();
@@ -63,7 +64,7 @@ define([
         segmentGroup.label = new peaks.options.segmentLabelDraw(segmentGroup, segment);
         segmentGroup.add(segmentGroup.label.hide());
 
-        if (editable) {
+        if (segment.editable) {
           var draggable = true;
 
           segmentGroup.inMarker = new peaks.options.segmentInMarker(draggable, segmentGroup, segment, segmentHandleDrag);
@@ -190,29 +191,32 @@ define([
      * Manage a new segment and propagates it into the different views
      *
      * @api
-     * @param {Number} startTime
-     * @param {Number} endTime
-     * @param {Boolean} editable
-     * @param {String=} color
-     * @param {String=} labelText
+     * @param {Object} options
+     * @param {Number} options.startTime
+     * @param {Number} options.endTime
+     * @param {Boolean=} options.editable
+     * @param {String=} options.color
+     * @param {String=} options.labelText
      * @return {Object}
      */
-    this.createSegment = function (startTime, endTime, editable, color, labelText) {
-      var segmentId = "segment" + self.segments.length;
-
-      if ((startTime >= 0) === false){
+    this.createSegment = function (options) {
+      if (typeof options === 'number'){ // watch for anyone still trying to use the old createSegment(startTime, endTime ... ) API
+        throw new TypeError("[waveform.segments.createSegment] `options` should be a Segment object");
+      }
+      
+      if ((options.startTime >= 0) === false){
         throw new TypeError("[waveform.segments.createSegment] startTime should be a positive value");
       }
 
-      if ((endTime > 0) === false){
+      if ((options.endTime > 0) === false){
         throw new TypeError("[waveform.segments.createSegment] endTime should be a positive value");
       }
 
-      if ((endTime > startTime) === false){
+      if ((options.endTime > options.startTime) === false){
         throw new RangeError("[waveform.segments.createSegment] endTime should be higher than startTime");
       }
 
-      var segment = createSegmentWaveform(segmentId, startTime, endTime, editable, color, labelText);
+      var segment = createSegmentWaveform(options);
 
       updateSegmentWaveform(segment);
       self.segments.push(segment);

--- a/test/unit/api-points-spec.js
+++ b/test/unit/api-points-spec.js
@@ -29,16 +29,16 @@
       });
 
       it("should return any added point", function () {
-        p.points.add(10, true, "#ff0000", "A point");
-        p.points.add(12, true, "#ff0000", "Another point");
+        p.points.add({timestamp: 10});
+        p.points.add({timestamp: 12});
         expect(p.points.getPoints()).to.have.length.of(2);
       });
     });
 
 
     describe("add", function () {
-      it("should create a segment with the mandatory values as arguments", function () {
-        p.points.add(10, true, "#ff0000", "A point");
+      it("should create a segment from the supplied object", function () {
+        p.points.add({ timestamp: 10, editable: true, color: "#ff0000", labelText: "A point"});
 
         var point = p.points.getPoints()[0];
 
@@ -57,48 +57,53 @@
         expect(p.points.getPoints()[1]).to.include.keys('timestamp', 'labelText');
       });
 
-      it("should throw an exception if argument is an object", function () {
-        expect(function () {
-          p.points.add({ timestamp: 10, editable: true, color: "#ff0000", labelText: "A point"});
-        }).to.throw(TypeError);
-      });
-
-      it("should throw an exception if arguments are empty", function () {
-        expect(function () {
-          p.points.add();
-        }).to.throw(TypeError);
+      it("should accept spread-arguments (deprecated)", function () {
+        p.options.deprecationLogger = function() {}
+        p.points.add(10, true, "#ff0000", "A point");
+        expect(p.points.getPoints()).to.have.a.lengthOf(1).and.to.have.deep.property('[0].timestamp', 10);
       });
 
       it("should throw an exception if timestamp argument is undefined", function () {
         expect(function () {
-          p.points.add(undefined);
+          p.points.add({timestamp: undefined});
         }).to.throw(TypeError);
       });
 
       it("should throw an exception if timestamp argument is null", function () {
         expect(function () {
-          p.points.add(null);
+          p.points.add({timestamp: null});
         }).to.throw(TypeError);
+      });
+
+      it("should throw an exception if the timestamp argument is NaN", function () {
+        expect(function () {
+          p.options.deprecationLogger = function() {}
+          p.points.add(NaN);
+        }).to.throw(RangeError);
+
+        expect(function () {
+          p.points.add({timestamp: NaN});
+        }).to.throw(RangeError);
       });
 
       it("should throw an exception if the timestamp argument is missing", function () {
         expect(function () {
-          p.points.add(NaN);
-        }).to.throw(RangeError);
+          p.points.add({});
+        }).to.throw(TypeError);
 
         expect(function () {
           p.points.add([
             {editable: true }
           ]);
-        }).to.throw(RangeError);
+        }).to.throw(TypeError);
       });
 
     });
 
     describe("removeByTime", function () {
       beforeEach(function(){
-        p.points.add(10, true, "#ff0000", "A point");
-        p.points.add(12, false, "#ff0000", "Another point");
+        p.points.add({timestamp: 10, editable: true});
+        p.points.add({timestamp: 12, editable: false});
       });
 
       it("should remove one of the point", function () {
@@ -111,6 +116,7 @@
         p.points.removeByTime(10);
 
         expect(p.points.getPoints()).to.have.deep.property('[0].id', 'point1');
+        expect(p.points.getPoints()).to.have.deep.property('[0].timestamp', 12);
       });
     });
 

--- a/test/unit/api-segments-spec.js
+++ b/test/unit/api-segments-spec.js
@@ -31,16 +31,25 @@
       });
 
       it("should return any added segment", function(){
-        p.segments.addSegment(0, 10);
-        p.segments.addSegment(2, 12);
+        p.segments.addSegment({startTime: 0, endTime: 10});
+        p.segments.addSegment({startTime: 2, endTime: 12});
 
         expect(p.segments.getSegments()).to.have.length.of(2);
       });
     });
 
     describe("addSegment", function(){
-      it("should create a segment with the mandatory values as arguments", function(){
+      it("should accept a list of properties for a single segment (deprecated)", function(){
+        p.options.deprecationLogger = function() {}
         p.segments.addSegment(0, 10);
+        expect(p.segments.getSegments()).to.have.length.of(1);
+        expect(p.segments.getSegments()[0]).to.include.keys('startTime', 'endTime');
+        expect(p.segments.getSegments()[0].startTime).to.equal(0)
+        expect(p.segments.getSegments()[0].endTime).to.equal(10)
+      })
+
+      it("should create a segment with the mandatory values as arguments", function(){
+        p.segments.addSegment({startTime: 0, endTime: 10});
         var segment = p.segments.getSegments()[0];
 
         expect(segment.startTime).to.equal(0);
@@ -51,13 +60,15 @@
 
       it("should throw an exception if the endTime argument is missing is missing", function(){
         expect(function(){
-          p.segments.addSegment(0);
-        }).to.throw(TypeError);
-
-        expect(function(){
           p.segments.addSegment([{startTime: 0 }]);
         }).to.throw(TypeError);
       });
+
+      it("should accept a single segment object", function(){
+        p.segments.addSegment({startTime: 0, endTime: 10});
+        expect(p.segments.getSegments()).to.have.length.of(1);
+        expect(p.segments.getSegments()[0]).to.include.keys('startTime', 'endTime');
+      })
 
       it("should accept an array of segments objects", function(){
         var segments = [{ startTime: 0, endTime: 10}, { startTime: 5, endTime: 10 }];
@@ -69,8 +80,8 @@
       });
 
       it("should throw an exception if arguments are not matching any previous accepted signature form", function(){
-        expect(function(){ p.segments.addSegment({startTime: 0, endTime: 10}); }).to.throw(TypeError);
-        expect(function(){ p.segments.addSegment(); }).to.throw(TypeError);
+        p.options.deprecationLogger = function() {}
+        expect(function(){ p.segments.addSegment({}); }).to.throw(TypeError);
         expect(function(){ p.segments.addSegment(undefined); }).to.throw(TypeError);
         expect(function(){ p.segments.addSegment(null); }).to.throw(TypeError);
         expect(function(){ p.segments.addSegment(NaN, NaN); }).to.throw(TypeError);
@@ -79,7 +90,7 @@
 
     describe("remove", function(){
       beforeEach(function(){
-        p.segments.add(10, 12);
+        p.segments.add({startTime: 10, endTime: 12});
       });
 
       it("should throw an exception if you remove a segment which does not exist", function(){
@@ -112,11 +123,11 @@
 
     describe("removeByTime", function(){
       beforeEach(function(){
-        p.segments.addSegment(10, 12);
-        p.segments.addSegment(5, 12);
+        p.segments.addSegment({startTime: 10, endTime: 12});
+        p.segments.addSegment({startTime: 5, endTime: 12});
 
-        p.segments.addSegment(3, 6);
-        p.segments.addSegment(3, 10);
+        p.segments.addSegment({startTime: 3, endTime: 6});
+        p.segments.addSegment({startTime: 3, endTime: 10});
       });
 
       it("should not remove any segment if the startTime does not match with any segment", function(){
@@ -156,8 +167,8 @@
 
     describe("removeAll", function(){
       beforeEach(function(){
-        p.segments.addSegment(10, 12);
-        p.segments.addSegment(5, 12);
+        p.segments.addSegment({startTime: 10, endTime: 12});
+        p.segments.addSegment({startTime: 5, endTime: 12});
       });
 
       it("should clear all segments objects", function(){

--- a/test/unit/waveform-segments-spec.js
+++ b/test/unit/waveform-segments-spec.js
@@ -25,7 +25,15 @@
     });
 
     describe("addSegment", function(){
-      it("should accept spreaded arguments (soon deprecated)", function(){
+      it("should accept a single Segment object", function(){
+        var spy = sandbox.spy(p.waveform.segments, 'createSegment');
+        p.segments.addSegment({ startTime: 0, endTime: 10, editable: false })
+        expect(spy.callCount).to.equal(1);
+        expect(spy.args[0]).to.deep.equal([0, 10, false, undefined, undefined]);
+      });
+
+      it("should accept spreaded arguments (deprecated)", function(){
+        p.options.deprecationLogger = function() {}
         var stub = sandbox.stub(p.waveform.segments, 'createSegment');
 
         p.segments.addSegment(0, 10, false);

--- a/test/unit/waveform-segments-spec.js
+++ b/test/unit/waveform-segments-spec.js
@@ -29,7 +29,7 @@
         var spy = sandbox.spy(p.waveform.segments, 'createSegment');
         p.segments.addSegment({ startTime: 0, endTime: 10, editable: false })
         expect(spy.callCount).to.equal(1);
-        expect(spy.args[0]).to.deep.equal([0, 10, false, undefined, undefined]);
+        expect(spy.args[0][0]).to.deep.equal({ startTime: 0, endTime: 10, editable: false });
       });
 
       it("should accept spreaded arguments (deprecated)", function(){
@@ -39,7 +39,7 @@
         p.segments.addSegment(0, 10, false);
 
         expect(stub.callCount).to.equal(1);
-        expect(stub.args[0]).to.deep.equal([0, 10, false, undefined, undefined]);
+        expect(stub.args[0][0]).to.deep.equal({startTime: 0, endTime: 10, editable: false, color: undefined, labelText: undefined});
       });
 
       it("should accept an array of Segment objects", function(){
@@ -51,7 +51,7 @@
         ]);
 
         expect(spy.callCount).to.equal(2);
-        expect(spy.args[1]).to.deep.equal([10, 20, true, 'rgba(255, 161, 39, 1)', 'dummy text']);
+        expect(spy.args[1][0]).to.deep.equal({startTime: 10, endTime: 20, editable: true, color: 'rgba(255, 161, 39, 1)', labelText: 'dummy text'});
       });
 
       it("should paint once, and not after each segment addition", function(){


### PR DESCRIPTION
It now warns on `addSegment(0, 10, …)` - a segment object should be passed instead.

eg - 
```js
  addSegment({startTime: 0, endTime: 10, …})
  addSegment([{startTime: 0, endTime: 10, …}, {startTime: 10, endTime: 20, …}])
```

---

This is something of a work in progress - I want to change `points.add` to follow the same signature, but thought I should get feedback on whether this is going in the right direction first.   In particular, I think it's a little weird that `segments.addSegment` now takes a segment-object, but then breaks it back out to spread-arguments for `waveform.segments.createSegment`.   WDYT to just passing the segment-object directly to createSegment ?

(Previously: #141 & #6)



