### PR TITLE
Use Konva.FastLayer for drawing waveforms

### DIFF
--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -29,7 +29,8 @@ define([
       height: that.height
     });
 
-    that.waveformLayer = new Konva.Layer();
+    that.backgroundLayer = new Konva.Layer();
+    that.waveformLayer = new Konva.FastLayer();
 
     that.background = new Konva.Rect({
       x: 0,
@@ -38,7 +39,8 @@ define([
       height: that.height
     });
 
-    that.waveformLayer.add(that.background);
+    that.backgroundLayer.add(that.background);
+    that.stage.add(that.backgroundLayer);
 
     that.createWaveform();
     that.createRefWaveform();

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -45,7 +45,8 @@ define([
       height: that.height
     });
 
-    that.zoomWaveformLayer = new Konva.Layer();
+    that.backgroundLayer = new Konva.Layer();
+    that.zoomWaveformLayer = new Konva.FastLayer();
     that.uiLayer = new Konva.Layer();
 
     that.background = new Konva.Rect({
@@ -55,7 +56,8 @@ define([
       height: that.height
     });
 
-    that.zoomWaveformLayer.add(that.background);
+    that.backgroundLayer.add(that.background);
+    that.stage.add(that.backgroundLayer);
 
     that.axis = new WaveformAxis(that);
 


### PR DESCRIPTION
FastLayer doesn’t support, eg, hit-testing, which makes it way faster when rendering large waveforms.