### PR TITLE
Report XHR errors

### DIFF
--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -107,6 +107,10 @@ define([
           }
         };
 
+        xhr.onerror = function() {
+          peaks.emit('error', new Error('XHR Failed'));
+        };
+
         xhr.send();
       },
 


### PR DESCRIPTION
If the XHR fails for some reason (perhaps because of [annoying cross-origin-redirect bugs](https://bugs.webkit.org/show_bug.cgi?id=57600)), the error is quietly swallowed.   How about reporting it via `peaks.emit('error')` ?